### PR TITLE
Conserta regex para strings de múltiplas linhas

### DIFF
--- a/lexer/lexer.l
+++ b/lexer/lexer.l
@@ -49,12 +49,30 @@ void print_simple_token(const char* token_name) {
 \{[0-9]+,\}                { print_simple_token("T_BRACE_RANGE"); return T_BRACE_RANGE; }
 \{[0-9]+,[0-9]+\}          { print_simple_token("T_BRACE_RANGE"); return T_BRACE_RANGE; }
 
-\"([^\"\\]|\\.)*\"          { yylval.strval = strdup(yytext); 
-                             print_token("T_STRING", yytext); 
-                             return T_STRING; }
-\'([^\'\\]|\\.)*\'          { yylval.strval = strdup(yytext); 
-                             print_token("T_STRING", yytext); 
-                             return T_STRING; }
+\'([^\\\n']|\\.)*\' {
+    yylval.strval = strdup(yytext);
+    print_token("T_STRING", yytext);
+    return T_STRING;
+}
+
+\"([^\\\n"]|\\.)*\" {
+    yylval.strval = strdup(yytext);
+    print_token("T_STRING", yytext);
+    return T_STRING;
+}
+
+"\'\'\'"([^\\]|\\.|\\\n)*?"\'\'\'" {
+    yylval.strval = strdup(yytext);
+    print_token("T_STRING", yytext);
+    return T_STRING;
+}
+
+"\"\"\""([^\\]|\\.|\\\n)*?"\"\"\"" {
+    yylval.strval = strdup(yytext);
+    print_token("T_STRING", yytext);
+    return T_STRING;
+}
+
 
 "and"                      { print_simple_token("T_AND"); return T_AND; }
 "or"                       { print_simple_token("T_OR"); return T_OR; }

--- a/tests/tests_sint_extras.py
+++ b/tests/tests_sint_extras.py
@@ -30,3 +30,9 @@ contador = 3
 while contador > 0:
     print(mostrar())
     contador = contador - 1
+
+print('''
+    oioi string
+    com múltiplas
+    linhas
+''')


### PR DESCRIPTION
Adição de regex adicionais para lidar com os diferentes usos de strings. Sugiro manter os comentários com apenas 1 linha por enquanto.

Closes #36, #29 